### PR TITLE
DM-35490: Initial version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '09:00'
+      timezone: America/Toronto

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+
+  pre-commit:
+    name: Lint with pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install pre-commit
+        run: |
+          pip install --upgrade pre-commit
+          pre-commit install
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-dependabot
+      # Schema is not compatible with a composite action
+      # - id: check-github-actions

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 LSST SQuaRE
+Copyright (c) 2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: init
+init:
+	pip install --upgrade pip pre-commit
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# build-and-push-to-ghcr
+# lsst-sqre/build-and-push-to-ghcr
 
 A composite GitHub Actions action that builds a Docker image, tags it based on the current Git branch/tag, and pushes it to ghcr.io.
 
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    # (optional) only build on tags or tickets branches
+    # (optional) only build on tags or ticket branches
     if: >
       startsWith(github.ref, 'refs/tags/')
       || startsWith(github.head_ref, 'tickets/')
@@ -32,10 +32,10 @@ jobs:
           image: ${{ github.repository }} # e.g. lsst-sqre/safirdemo
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo Pushed ghcr.io/${{ github.repository }}/${{ steps.build.outputs.tag }}
+      - run: echo Pushed ghcr.io/${{ github.repository }}:${{ steps.build.outputs.tag }}
 ```
 
-By default gchr.io packages are named after the GitHub repository.
+By default, ghcr.io packages are named after the GitHub repository.
 To automatically set that, the above example uses the context variable `${{ github.repository }}` as the image name.
 
 ## Action reference

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# build-and-push-to-ghrc
+# build-and-push-to-ghcr
 
 A composite GitHub Actions action that builds a Docker image, tags it based on the current branch/tag, and pushes it to ghcr.io.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To automatically set that, the above example uses the context variable `${{ gith
 
 - `dockerfile` (string, optional) the path to the Dockerfile to build. Default is `Dockerfile`.
 
+- `context` (string, optional) the [Docker build context](https://docs.docker.com/build/building/context/). Default is `.`.
+
 - `push` (boolean, optional) a flag to enable pushing to ghcr.io. Default is `true`.
   If `false`, the action skips the push to ghcr.io, but still builds the image with [`docker build`](https://docs.docker.com/engine/reference/commandline/build/).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,68 @@
 # build-and-push-to-ghcr
 
-A composite GitHub Actions action that builds a Docker image, tags it based on the current branch/tag, and pushes it to ghcr.io.
+A composite GitHub Actions action that builds a Docker image, tags it based on the current Git branch/tag, and pushes it to ghcr.io.
+
+## Usage
+
+```yaml
+name: CI
+
+"on":
+  merge_group: {}
+  pull_request: {}
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # (optional) only build on tags or tickets branches
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: lsst-sqre/build-and-push-to-ghcr@v1
+        id: build
+        with:
+          image: ${{ github.repository }} # e.g. lsst-sqre/safirdemo
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: echo Pushed ghcr.io/${{ github.repository }}/${{ steps.build.outputs.tag }}
+```
+
+By default gchr.io packages are named after the GitHub repository.
+To automatically set that, the above example uses the context variable `${{ github.repository }}` as the image name.
+
+## Action reference
+
+### Inputs
+
+- `image` (string, required) the name of the image to build and push. The image does not include the registry (`ghcr.io/`) or the tag.
+  For example, the image input for `ghcr.io/owner/repo:tag` image is `owner/repo`.
+
+- `github_token` (string, required) the GitHub token to use for pushing to ghcr.io. Default is `${{ secrets.GITHUB_TOKEN }}`.
+
+- `dockerfile` (string, optional) the path to the Dockerfile to build. Default is `Dockerfile`.
+
+- `push` (boolean, optional) a flag to enable pushing to ghcr.io. Default is `true`.
+  If `false`, the action skips the push to ghcr.io, but still builds the image with [`docker build`](https://docs.docker.com/engine/reference/commandline/build/).
+
+### Outputs
+
+- `tag` (string) the tag of the image that was pushed to ghcr.io.
+
+## Developer guide
+
+This repository provides a **composite** GitHub Action, a type of action that packages multiple regular actions into a single step.
+We do this to make the GitHub Actions of all our software projects more consistent and easier to maintain.
+[You can learn more about composite actions in the GitHub documentation.](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
+
+Create new releases using the GitHub Releases UI and assign a tag with a [semantic version](https://semver.org), including a `v` prefix. Choose the semantic version based on compatibility for users of this workflow. If backwards compatibility is broken, bump the major version.
+
+When a release is made, a new major version tag (i.e. `v1`, `v2`) is also made or moved using [nowactions/update-majorver](https://github.com/marketplace/actions/update-major-version).
+We generally expect that most users will track these major version tags.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # build-and-push-to-ghrc
-Build a Docker image, auto-tag, and push it to ghcr.io
+
+A composite GitHub Actions action that builds a Docker image, tags it based on the current branch/tag, and pushes it to ghcr.io.

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,54 @@
+name: "Build and push to ghcr.io"
+description: >
+  This composite action builds a Docker image, tags it with the current git
+  branch/tag ref, and pushes it to ghcr.io.
+inputs:
+  github_token:
+    description: "The GitHub token to use for authentication."
+    required: true
+  image:
+    description: "The name of the Docker image to build."
+    required: true
+  dockerfile:
+    description: "The name of the Dockerfile to build."
+    required: false
+    default: "Dockerfile"
+  push:
+    description: "Whether to push the image to ghcr.io."
+    required: false
+    default: "true"
+outputs:
+  tag:
+    description: "The tag of the Docker image that was built."
+    value: ${{ steps.tag.outputs.tag }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Define the tag
+      id: tag
+      shell: bash
+      run: echo "tag=`bash ${{ github.action_path  }}/docker-tag.sh`" >> ${GITHUB_OUTPUT}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v2
+      if: fromJSON(inputs.push) == true
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.github_token }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: "."
+        file: "${{ inputs.dockerfile }}"
+        push: ${{ fromJSON(inputs.push) == true }}
+        tags: |
+          ghcr.io/${{ inputs.image }}:${{ steps.tag.outputs.tag }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: "The name of the Dockerfile to build."
     required: false
     default: "Dockerfile"
+  context:
+    description: "The build context to use."
+    required: false
+    default: "."
   push:
     description: "Whether to push the image to ghcr.io."
     required: false
@@ -45,7 +49,7 @@ runs:
     - name: Build and push
       uses: docker/build-push-action@v4
       with:
-        context: "."
+        context: "${{ inputs.context }}"
         file: "${{ inputs.dockerfile }}"
         push: ${{ fromJSON(inputs.push) == true }}
         tags: |

--- a/docker-tag.sh
+++ b/docker-tag.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
+
+set -eo pipefail
+
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
+fi


### PR DESCRIPTION
This is the initial version of the lsst-sqre/build-and-push-to-ghcr composite action. This action solves two main problems:

- The orignal syntax for storing the tag output into the GitHub Actions running context is deprecated. This action uses the new `$GITHUB_OUTPUT` syntax.
- Each app needed a copy of the docker-tag.sh script. This composite action ships that script.

An example of this action running is at https://github.com/lsst-sqre/squarebot/pull/23