### PR TITLE
DM-41857: Add cache-from and cache-to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ To automatically set that, the above example uses the context variable `${{ gith
 - `push` (boolean, optional) a flag to enable pushing to ghcr.io. Default is `true`.
   If `false`, the action skips the push to ghcr.io, but still builds the image with [`docker build`](https://docs.docker.com/engine/reference/commandline/build/).
 
+- `cache-from` (string, optional) a comma-separated list of Docker buildx cache sources.
+  Default is `type=gha` to use the GitHub Actions cache.
+  Set as `type=local,src=/tmp/.buildx-cache` to use a local cache.
+
+- `cache-to` (string, optional) a comma-separated list of Docker buildx cache destinations.
+  Default is `type=gha,mode=max` to use the GitHub Actions cache.
+  Set as `type=local,dest=/tmp/.buildx-cache` to use a local cache.
+
 ### Outputs
 
 - `fully_qualified_image_digest` (string) A complete, unique, and immutable identifier for the built image,

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,14 @@ inputs:
     description: "Whether to push the image to ghcr.io."
     required: false
     default: "true"
+  cache-from:
+    description: "List of external cache sources for buildx."
+    required: false
+    default: "type=gha"
+  cache-to:
+    description: "List of cache export destinations for buildx."
+    required: false
+    default: "type=gha,mode=max"
 outputs:
   tag:
     description: "The tag of the Docker image that was built."
@@ -58,5 +66,5 @@ runs:
         push: ${{ fromJSON(inputs.push) == true }}
         tags: |
           ghcr.io/${{ inputs.image }}:${{ steps.tag.outputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}


### PR DESCRIPTION
The default values for these inputs remain consistent with the previous
hard-coded values:

```
cache-from: type=gha
cache-to: type=gha,mode=max
```

The reason to change these inputs would be to customize the caching
behaviour. For example, set to `local` to prevent the docker image from
being cached altogether.