### PR TITLE
DM-45760: Add Multi-platform image builds with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To automatically set that, the above example uses the context variable `${{ gith
 - `push` (boolean, optional) a flag to enable pushing to ghcr.io. Default is `true`.
   If `false`, the action skips the push to ghcr.io, but still builds the image with [`docker build`](https://docs.docker.com/engine/reference/commandline/build/).
 
+- `platforms` (list, optional) List of target platform for build.
+
 ### Outputs
 
 - `fully_qualified_image_digest` (string) A complete, unique, and immutable identifier for the built image,

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,9 @@ inputs:
     description: "Whether to push the image to ghcr.io."
     required: false
     default: "true"
+  platforms:
+    description: "List of target platforms for build"
+    required: false
 outputs:
   tag:
     description: "The tag of the Docker image that was built."
@@ -37,6 +40,9 @@ runs:
       id: tag
       shell: bash
       run: echo "tag=`bash ${{ github.action_path  }}/docker-tag.sh`" >> ${GITHUB_OUTPUT}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -56,6 +62,7 @@ runs:
         context: "${{ inputs.context }}"
         file: "${{ inputs.dockerfile }}"
         push: ${{ fromJSON(inputs.push) == true }}
+        platforms: ${{ inputs.platforms }}
         tags: |
           ghcr.io/${{ inputs.image }}:${{ steps.tag.outputs.tag }}
         cache-from: type=gha


### PR DESCRIPTION
- Add setup-qemu-action to allow multi-platform builds.
- Add optional platforms field
- Update Readme 