### PR TITLE
DM-48192 : Support optional target and build-args in build action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,12 @@ inputs:
   platforms:
     description: "List of target platforms for build"
     required: false
+  target:
+    description: "Name of target stage to build"
+    required: false
+  build-args:
+    description: "List of build-time variables"
+    required: false
 outputs:
   tag:
     description: "The tag of the Docker image that was built."
@@ -61,6 +67,8 @@ runs:
       with:
         context: "${{ inputs.context }}"
         file: "${{ inputs.dockerfile }}"
+        build-args: "${{ inputs.build-args }}"
+        target: "${{ inputs.target }}"
         push: ${{ fromJSON(inputs.push) == true }}
         platforms: ${{ inputs.platforms }}
         tags: |


### PR DESCRIPTION
This PR allows the GitHub action to pick up `target` and `build-args` inputs and pass them through to the Docker action.

Specifying a target allows one to specify a build stage in a Dockerfile as the target of the build, and build-args can be picked up by `ARG` statements to make variable builds.