### PR TITLE
DM-54790: Expose cache-from and cache-to as optional inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ To automatically set that, the above example uses the context variable `${{ gith
 
 - `additional-tags` (list, optional) A newline-delimited list of additional tags to be added to the built image. These can be string literals or can conform to the `docker/metadata-action` [tags grammar](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input).
 
+- `cache-from` (list, optional) buildx cache sources, one per line. Forwarded directly to `docker/build-push-action`. Default is `type=gha`, which uses the GitHub Actions cache. The GHA cache is capped at 10 GB per repository and is branch-scoped, which is fine for most images but causes severe cache eviction for very large images (tens of GB or more). For those cases, override with a registry-backed cache, for example:
+
+  ```yaml
+  cache-from: |
+    type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ github.head_ref || github.ref_name }}
+    type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-main
+  ```
+
+- `cache-to` (string, optional) buildx cache destination, forwarded directly to `docker/build-push-action`. Default is `type=gha,mode=max`. Override alongside `cache-from` to use a different cache backend, for example a registry-backed cache:
+
+  ```yaml
+  cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ github.head_ref || github.ref_name }},mode=max
+  ```
+
+  Set to an empty string to disable cache export entirely. Note that pushing to a registry cache requires `packages: write` permission on the workflow's `GITHUB_TOKEN`.
+
 ### Outputs
 
 - `fully_qualified_image_digest` (string) A complete, unique, and immutable identifier for the built image,

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,24 @@ inputs:
   secrets:
     description: "Secrets to mount when building the image"
     required: false
+  cache-from:
+    description: >-
+      buildx cache sources, one per line (forwarded to
+      docker/build-push-action). Default uses the GitHub Actions
+      cache, which is capped at 10 GB per repo and is branch-scoped.
+      Override with e.g.
+      ``type=registry,ref=ghcr.io/<owner>/<repo>:buildcache`` for
+      large images that don't fit in the GHA cache.
+    required: false
+    default: "type=gha"
+  cache-to:
+    description: >-
+      buildx cache destination (forwarded to
+      docker/build-push-action). Override alongside ``cache-from``
+      to use a different cache backend. Set to an empty string to
+      disable cache export entirely.
+    required: false
+    default: "type=gha,mode=max"
 outputs:
   tag:
     description: "The tag of the Docker image that was built."
@@ -90,5 +108,5 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         secrets: "${{ inputs.secrets }}"
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}


### PR DESCRIPTION
Adds two new optional inputs that are forwarded directly to the underlying docker/build-push-action step. Defaults preserve the current behaviour exactly (``type=gha`` / ``type=gha,mode=max``), so existing callers see no change.

The motivation is that the GitHub Actions cache is capped at 10 GB per repository and is branch-scoped, which causes severe cache eviction for very large images (tens of GB or more). Callers in that situation can now opt in to a registry-backed cache, e.g.

    cache-from: |
      type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ github.head_ref || github.ref_name }}
      type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-main
    cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ github.head_ref || github.ref_name }},mode=max

without having to fork the action or drop down to calling docker/build-push-action directly.

README is updated with both inputs and an example registry-cache override, including the note that registry-cache writes require ``packages: write`` on the workflow token.